### PR TITLE
[FIX] Fixes retireval of non-existent dictionary key. Fixes #1 

### DIFF
--- a/mail_tools/ip_address.py
+++ b/mail_tools/ip_address.py
@@ -34,7 +34,7 @@ class IpAddress:
                 if re.match(regex, netiface):
                     continue
                 addrs = netifaces.ifaddresses(netiface)
-                for item in addrs[netifaces.AF_INET]:
+                for item in addrs.get(netifaces.AF_INET, []):
                     if 'addr' in item.keys():
                         netifaces_ips.append({'netiface': netiface,
                                               'ip':       item['addr'], })


### PR DESCRIPTION
[FIX] Fixes retireval of non-existent dictionary key using `get(dic, default)` method, passing a default value to avoid next loop. Fixes #1 
